### PR TITLE
 Add source filter allong with new QueryProperties construct

### DIFF
--- a/docs/advanced-queries.md
+++ b/docs/advanced-queries.md
@@ -43,3 +43,20 @@ $results = Post::search('Self-steering')
     ->field('published_at')
     ->get();
 ```
+
+## Query properties
+
+Elastic has a multitude of options one can add to its queries.
+
+In Explorer one can easily add these with Query Properties, you can create a class , implement the `QueryProperty` interface
+and pass it to the query. An example of this is source field filtering which we included in the SourceFilter class.
+
+```php
+use App\Models\Post;
+use Hilsonxhero\ElasticVision\Domain\Query\QueryProperties\SourceFilter;
+
+$results = Post::search('Self-steering')
+    ->field('id')
+    ->property(SourceFilter::empty()->include('*.description')->exclude('*_secret'))
+    ->get();
+```

--- a/src/Domain/Query/Query.php
+++ b/src/Domain/Query/Query.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Hilsonxhero\ElasticVision\Domain\Query;
 
-use Hilsonxhero\ElasticVision\Domain\Aggregations\AggregationSyntaxInterface;
 use Hilsonxhero\ElasticVision\Domain\Syntax\Sort;
+use Hilsonxhero\ElasticVision\Domain\Query\Rescoring;
 use Hilsonxhero\ElasticVision\Domain\Syntax\SyntaxInterface;
+use Hilsonxhero\ElasticVision\Domain\Query\QueryProperties\QueryProperty;
+use Hilsonxhero\ElasticVision\Domain\Aggregations\AggregationSyntaxInterface;
 
 class Query implements SyntaxInterface
 {
@@ -21,6 +23,9 @@ class Query implements SyntaxInterface
 
     /** @var Sort[] */
     private array $sort = [];
+
+    /** @var QueryProperty[]  */
+    private array $queryProperties = [];
 
     private SyntaxInterface $query;
 
@@ -67,12 +72,22 @@ class Query implements SyntaxInterface
             );
         }
 
-        return $query;
+        $allQueryProperties = array_map(
+            static fn (QueryProperty $queryProperties) => $queryProperties->build(),
+            $this->queryProperties
+        );
+
+        return array_merge($query, ...$allQueryProperties);
     }
 
     public function setOffset(?int $offset): void
     {
         $this->offset = $offset;
+    }
+
+    public function addQueryProperties(QueryProperty ...$properties): void
+    {
+        array_push($this->queryProperties, ...$properties);
     }
 
     public function setLimit(?int $limit): void

--- a/src/Domain/Query/QueryProperties/QueryProperty.php
+++ b/src/Domain/Query/QueryProperties/QueryProperty.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hilsonxhero\ElasticVision\Domain\Query\QueryProperties;
+
+interface QueryProperty
+{
+    public function build(): array;
+}

--- a/src/Domain/Query/QueryProperties/SourceFilter.php
+++ b/src/Domain/Query/QueryProperties/SourceFilter.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hilsonxhero\ElasticVision\Domain\Query\QueryProperties;
+
+class SourceFilter implements QueryProperty
+{
+    /**
+     * @param string[]|null $include
+     * @param string[]|null $exclude
+     */
+    private function __construct(
+        private ?array $include = null,
+        private ?array $exclude = null,
+    ) {
+    }
+
+    public static function empty(): self
+    {
+        return new self();
+    }
+
+    public function include(string ...$fields): self
+    {
+        $include = $this->include ?? [];
+        array_push($include, ...$fields);
+
+        return new self(
+            include: $include,
+            exclude: $this->exclude,
+        );
+    }
+
+    public function exclude(string ...$fields): self
+    {
+        $exclude = $this->exclude ?? [];
+        array_push($exclude, ...$fields);
+
+        return new self(
+            include: $this->include,
+            exclude: $exclude,
+        );
+    }
+
+    public function build(): array
+    {
+        if ($this->exclude === null && $this->include === null) {
+            return [];
+        }
+
+        $source = [];
+        if (!is_null($this->include)) {
+            $source['include'] = $this->include;
+        }
+        if (!is_null($this->exclude)) {
+            $source['exclude'] = $this->exclude;
+        }
+
+        return [
+            '_source' => $source,
+        ];
+    }
+}

--- a/src/Infrastructure/Elastic/ElasticDocumentAdapter.php
+++ b/src/Infrastructure/Elastic/ElasticDocumentAdapter.php
@@ -9,6 +9,7 @@ use Hilsonxhero\ElasticVision\Application\DocumentAdapterInterface;
 use Hilsonxhero\ElasticVision\Application\Operations\Bulk\BulkOperationInterface;
 use Hilsonxhero\ElasticVision\Application\Results;
 use Hilsonxhero\ElasticVision\Application\SearchCommandInterface;
+use Elastic\Elasticsearch\Exception\MissingParameterException;
 
 final class ElasticDocumentAdapter implements DocumentAdapterInterface
 {
@@ -37,10 +38,13 @@ final class ElasticDocumentAdapter implements DocumentAdapterInterface
 
     public function delete(string $index, $id): void
     {
-        $this->client->delete([
-            'index' => $index,
-            'id' => $id
-        ]);
+        try {
+            $this->client->delete([
+                'index' => $index,
+                'id' => $id
+            ]);
+        } catch (MissingParameterException) {
+        }
     }
 
     public function search(SearchCommandInterface $command): Results

--- a/src/Providers/ServiceProvider.php
+++ b/src/Providers/ServiceProvider.php
@@ -3,16 +3,17 @@
 namespace Hilsonxhero\ElasticVision\Providers;
 
 use Laravel\Scout\Builder;
+use Laravel\Scout\EngineManager;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Hilsonxhero\ElasticVision\Infrastructure\Scout\ElasticEngine;
-use Hilsonxhero\ElasticVision\Infrastructure\Elastic\ElasticDocumentAdapter;
+use Hilsonxhero\ElasticVision\Domain\Query\QueryProperties\QueryProperty;
 use Hilsonxhero\ElasticVision\Infrastructure\Elastic\ElasticIndexAdapter;
 use Hilsonxhero\ElasticVision\Infrastructure\Elastic\ElasticClientBuilder;
 use Hilsonxhero\ElasticVision\Infrastructure\Elastic\ElasticClientFactory;
+use Hilsonxhero\ElasticVision\Infrastructure\Elastic\ElasticDocumentAdapter;
 use Hilsonxhero\ElasticVision\Domain\Aggregations\AggregationSyntaxInterface;
 use Hilsonxhero\ElasticVision\Infrastructure\IndexManagement\ElasticIndexConfigurationRepository;
-use Laravel\Scout\EngineManager;
 
 class ServiceProvider extends BaseServiceProvider
 {
@@ -83,6 +84,11 @@ class ServiceProvider extends BaseServiceProvider
 
         Builder::macro('aggregation', function (string $name, AggregationSyntaxInterface $aggregation) {
             $this->aggregations[$name] = $aggregation;
+            return $this;
+        });
+
+        Builder::macro('property', function (QueryProperty $queryProperty) {
+            $this->queryProperties[] = $queryProperty;
             return $this;
         });
 


### PR DESCRIPTION
- Add QueryProperties to extend the output json from the query
- and allow for user defined behavior on the query itself.
- Add SourceFilter as QueryProperty to allow for defining
- which fields are returned in the _source output